### PR TITLE
Fixing test for CentOS 7 ISSUE=248 PROJ=161

### DIFF
--- a/t/conf/extra.conf.in
+++ b/t/conf/extra.conf.in
@@ -27,7 +27,7 @@ PerlPassEnv PERL_TEST_HARNESS_DUMP_TAP
   AuthType Basic
   AuthName "The Realm"
   AuthUserFile htdocs/second-protected/auth_file
-  Require dummy
+  Require user dummy
 
   Order allow,deny
   Allow from all


### PR DESCRIPTION
Apache 2.4 on CentOS 7 is more strict about the `Require` directive syntax.