### PR TITLE
Adding ability to ignore ssl hostname checks

### DIFF
--- a/lib/GRNOC/WebService/Client.pm
+++ b/lib/GRNOC/WebService/Client.pm
@@ -740,6 +740,12 @@ sub AUTOLOAD {
 
 =cut
 
+=item verify_hostname
+
+    If set to 1 then ssl certs are validated. Set to 0 when working with untrusted or self-signed certs. Defaults to 1.
+
+=cut
+
 =item retry_error_codes
 
     hash of http error codes to retry the request on if the request fails
@@ -843,11 +849,14 @@ sub new {
         $self->{'urls'}{'0'}[0] = $self->{'url'};
     }
 
-    if ($self->{'use_keep_alive'}) {
-        $self->{'ua'}   = LWP::UserAgent::Determined->new(ssl_opts => {verify_hostname => $self->{'verify_hostname'}}, keep_alive => 1, agent => $self->{'user_agent'});
-    }
-    else {
-        $self->{'ua'}   = LWP::UserAgent::Determined->new(ssl_opts => {verify_hostname => $self->{'verify_hostname'}}, agent => $self->{'user_agent'});
+    {
+        no warnings;
+
+        $self->{'ua'} = LWP::UserAgent::Determined->new(
+            agent      => $self->{'user_agent'},
+            ssl_opts   => {verify_hostname => $self->{'verify_hostname'}},
+            keep_alive => $self->{'use_keep_alive'}
+        );
     }
 
     #---- check to see if we need to use old style urls. This allows us to use web services that don't parse semicolons the same as ampersands.

--- a/lib/GRNOC/WebService/Client.pm
+++ b/lib/GRNOC/WebService/Client.pm
@@ -850,7 +850,11 @@ sub new {
     }
 
     {
-        no warnings;
+        # In older versions of LWP::UserAgent::Determined the ssl_opts
+        # parameter is not defined, and a warning is logged to the
+        # command line. Setting $^W to zero surpresses these warnings
+        # within this block.
+        local ($^W) = 0;
 
         $self->{'ua'} = LWP::UserAgent::Determined->new(
             agent      => $self->{'user_agent'},

--- a/lib/GRNOC/WebService/Client.pm
+++ b/lib/GRNOC/WebService/Client.pm
@@ -766,7 +766,8 @@ sub new {
         oldstyle_urls  => 0,
         cookieJar        => undef,
         method_parameter => "method",
-        use_pagination => 0,
+        use_pagination   => 0,
+        verify_hostname  => 1,
         retry_error_codes => { '408' => 1,
                                '503' => 1,
                                '502' => 1,
@@ -843,10 +844,10 @@ sub new {
     }
 
     if ($self->{'use_keep_alive'}) {
-        $self->{'ua'}   = LWP::UserAgent::Determined->new(keep_alive => 1, agent => $self->{'user_agent'});
+        $self->{'ua'}   = LWP::UserAgent::Determined->new(ssl_opts => {verify_hostname => $self->{'verify_hostname'}}, keep_alive => 1, agent => $self->{'user_agent'});
     }
     else {
-        $self->{'ua'}   = LWP::UserAgent::Determined->new( agent => $self->{'user_agent'});
+        $self->{'ua'}   = LWP::UserAgent::Determined->new(ssl_opts => {verify_hostname => $self->{'verify_hostname'}}, agent => $self->{'user_agent'});
     }
 
     #---- check to see if we need to use old style urls. This allows us to use web services that don't parse semicolons the same as ampersands.


### PR DESCRIPTION
The LWP::UserAgent is more strict in CentOS 7, and will not fulfill requests with bad certs. This change exposes the `verify_hostname` parameter to disable certificate checks; This is useful when working with test systems that have a self-signed cert or no cert at all.

Unit tests pass on both rhel6 and centos7, although a warning is announced on rhel6.
```
Unrecognized LWP::UserAgent options: ssl_opts at /home/.../GRNOC-WebService-Client/blib/lib/GRNOC/WebService/Client.pm line 846.
```
