### PR TITLE
Adding a catchall check for landing back at a webpage when expecting …

### DIFF
--- a/lib/GRNOC/WebService/Client.pm
+++ b/lib/GRNOC/WebService/Client.pm
@@ -855,7 +855,17 @@ sub AUTOLOAD {
                 }
                 else
                 {
-                    $self->_set_error($@);
+
+		    # Try to do some error pretty-fication here for ease of understanding
+		    # If we're back at some webpage, it means that login failed for some reason
+		    # not caught earlier, do a catch all to make error prettier
+		    # This section is only used when expecting JSON based responses
+		    my $base_error = $@;
+		    if ($res =~ /<html/){
+			$base_error = "Unable to get JSON response from $base, possibly authentication/realm issues";
+		    }
+
+                    $self->_set_error($base_error);
                 }
             }
         }


### PR DESCRIPTION
…a JSON response along with some hints. This probably doesn't cover every case but it should handle some common ones we run into.